### PR TITLE
Add minimal auth service with JWT and rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore SQLite database files
+*.db

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# Backend
+
+## Authentication Token Flow
+
+1. **Sign up** via `POST /signup` with a JSON body containing `username` and `password`.
+   - On success the server creates a record in the `users` table and returns a signed JWT token.
+2. **Log in** via `POST /login` with the same credentials.
+   - When the credentials are valid the server returns a new JWT token.
+3. For authenticated requests include the token in the `Authorization` header using the `Bearer` scheme.
+   - Example: `Authorization: Bearer <token>`
+4. Use the token to fetch the current user by calling `GET /me` which responds with the user's id and username when the token is valid.
+
+Tokens are signed with HS256 using a server-side secret and expire when the secret changes. Rate limiting limits repeated calls to `/signup` and `/login` from the same IP address.

--- a/backend/auth/db.js
+++ b/backend/auth/db.js
@@ -1,0 +1,42 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+const dbPath = path.join(__dirname, 'users.db');
+
+function init() {
+  spawnSync('sqlite3', [dbPath, 'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);']);
+}
+
+function escape(value) {
+  return value.replace(/'/g, "''");
+}
+
+function addUser(username, password) {
+  const sql = `INSERT INTO users (username, password) VALUES ('${escape(username)}', '${escape(password)}');`;
+  const result = spawnSync('sqlite3', [dbPath, sql]);
+  if (result.status !== 0) {
+    const msg = result.stderr.toString();
+    if (msg.includes('UNIQUE constraint')) {
+      return { error: 'EXISTS' };
+    }
+    throw new Error(msg);
+  }
+  const idResult = spawnSync('sqlite3', [dbPath, 'SELECT last_insert_rowid();']);
+  const id = parseInt(idResult.stdout.toString().trim(), 10);
+  return { id };
+}
+
+function getUser(username) {
+  const sql = `SELECT id, username, password FROM users WHERE username = '${escape(username)}';`;
+  const result = spawnSync('sqlite3', ['-separator', '|', dbPath, sql]);
+  if (result.status !== 0) {
+    throw new Error(result.stderr.toString());
+  }
+  const output = result.stdout.toString().trim();
+  if (!output) return null;
+  const [id, uname, password] = output.split('|');
+  return { id: Number(id), username: uname, password };
+}
+
+init();
+
+module.exports = { addUser, getUser };

--- a/backend/auth/jwt.js
+++ b/backend/auth/jwt.js
@@ -1,0 +1,42 @@
+const crypto = require('crypto');
+
+function base64url(obj) {
+  return Buffer.from(JSON.stringify(obj))
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function sign(payload, secret) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const encodedHeader = base64url(header);
+  const encodedPayload = base64url(payload);
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(data)
+    .digest('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  return `${data}.${signature}`;
+}
+
+function verify(token, secret) {
+  const parts = token.split('.');
+  if (parts.length !== 3) throw new Error('Invalid token');
+  const [header, payload, signature] = parts;
+  const data = `${header}.${payload}`;
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(data)
+    .digest('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  if (signature !== expected) throw new Error('Invalid signature');
+  return JSON.parse(Buffer.from(payload, 'base64').toString());
+}
+
+module.exports = { sign, verify };

--- a/backend/auth/server.js
+++ b/backend/auth/server.js
@@ -1,0 +1,98 @@
+const http = require('http');
+const crypto = require('crypto');
+const { addUser, getUser } = require('./db');
+const { sign, verify } = require('./jwt');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'development-secret';
+const PORT = process.env.PORT || 3000;
+
+function hashPassword(password, salt = crypto.randomBytes(16).toString('hex')) {
+  const hash = crypto.scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+function checkPassword(password, stored) {
+  const [salt, hash] = stored.split(':');
+  const hashed = crypto.scryptSync(password, salt, 64).toString('hex');
+  return hash === hashed;
+}
+
+// simple in-memory rate limiter
+const limits = {};
+function rateLimit(ip, route, limit = 5, windowMs = 60 * 1000) {
+  const key = `${ip}:${route}`;
+  const now = Date.now();
+  const entry = limits[key] || { count: 0, start: now };
+  if (now - entry.start > windowMs) {
+    entry.count = 0;
+    entry.start = now;
+  }
+  entry.count++;
+  limits[key] = entry;
+  return entry.count <= limit;
+}
+
+function jsonResponse(res, status, obj) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const ip = req.socket.remoteAddress;
+
+  if (req.method === 'POST' && (url.pathname === '/signup' || url.pathname === '/login')) {
+    if (!rateLimit(ip, url.pathname)) {
+      return jsonResponse(res, 429, { error: 'Too many requests' });
+    }
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const { username, password } = JSON.parse(body || '{}');
+        if (!username || !password) {
+          return jsonResponse(res, 400, { error: 'Missing credentials' });
+        }
+        if (url.pathname === '/signup') {
+          const hashed = hashPassword(password);
+          const result = addUser(username, hashed);
+          if (result.error === 'EXISTS') {
+            return jsonResponse(res, 409, { error: 'User exists' });
+          }
+          const token = sign({ id: result.id, username }, JWT_SECRET);
+          return jsonResponse(res, 201, { token });
+        }
+        if (url.pathname === '/login') {
+          const user = getUser(username);
+          if (!user || !checkPassword(password, user.password)) {
+            return jsonResponse(res, 401, { error: 'Invalid credentials' });
+          }
+          const token = sign({ id: user.id, username }, JWT_SECRET);
+          return jsonResponse(res, 200, { token });
+        }
+      } catch (e) {
+        return jsonResponse(res, 400, { error: 'Invalid request' });
+      }
+    });
+  } else if (req.method === 'GET' && url.pathname === '/me') {
+    const auth = req.headers['authorization'];
+    if (!auth || !auth.startsWith('Bearer ')) {
+      return jsonResponse(res, 401, { error: 'Missing or invalid token' });
+    }
+    const token = auth.slice(7);
+    try {
+      const payload = verify(token, JWT_SECRET);
+      return jsonResponse(res, 200, { id: payload.id, username: payload.username });
+    } catch (err) {
+      return jsonResponse(res, 401, { error: 'Invalid token' });
+    }
+  } else {
+    jsonResponse(res, 404, { error: 'Not found' });
+  }
+});
+
+if (require.main === module) {
+  server.listen(PORT, () => console.log(`Auth service listening on port ${PORT}`));
+}
+
+module.exports = server;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "blablabla",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node backend/auth/server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- implement simple HTTP auth server exposing `/signup`, `/login`, and `/me` with JWT tokens
- persist user credentials in a SQLite `users` table and apply in-memory rate limiting
- document authentication token flow and add start script

## Testing
- `npm test` *(fails: no test specified)*
- `curl -X POST /signup` (returns JWT)
- `curl -X POST /login`
- `curl /me` with Bearer token

------
https://chatgpt.com/codex/tasks/task_b_6896954016288333b09ba3b0bf39d7d1